### PR TITLE
Feat: update out of sync fixtures

### DIFF
--- a/out-of-sync-npm/package.json
+++ b/out-of-sync-npm/package.json
@@ -11,6 +11,10 @@
   "dependencies": {
     "body-parser": "1.18.3",
     "debug": "4.1.0",
-    "snyk": "*"
+    "snyk": "*",
+    "lodash": "4.17.11",
+    "request": "^2.4.1",
+    "chalk": "~2.4.0",
+    "react": ">=15.6.1 <16.3.2"
   }
 }

--- a/out-of-sync/package.json
+++ b/out-of-sync/package.json
@@ -34,7 +34,11 @@
     "tap": "^5.7.0",
     "adm-zip": "0.4.7",
     "file-type": "^8.1.0",
-    "snyk": "*"
+    "snyk": "*",
+    "lodash": "4.17.11",
+    "request": "^2.4.1",
+    "chalk": "~2.4.0",
+    "react": ">=15.6.1 <16.3.2"
   },
   "devDependencies": {
     "browserify": "^13.1.1"


### PR DESCRIPTION
Add a few packages more to our package.json that we haven't propagated to our lockfiles
- "lodash": "4.17.11",
- "request": "^2.4.1",
- "chalk": "~2.4.0",
- "react": ">=15.6.1 <16.3.2"